### PR TITLE
implement new key insertion

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onLanguage:dart",
     "onCommand:flutterI18nJsonInit",
     "onCommand:flutterI18nJsonAdd",
     "onCommand:flutterI18nJsonUpdate",

--- a/src/InsertActionProvider.ts
+++ b/src/InsertActionProvider.ts
@@ -1,0 +1,112 @@
+import { CodeActionProvider, CodeActionKind, Range, CodeAction, TextDocument, DocumentFilter, CodeActionContext, Diagnostic, window, Position } from "vscode";
+import { I18nConfig, I18nFunction } from "./i18n.interfaces";
+
+export interface InsertActionProviderDelegate {
+    readConfigFileAsync(): Promise<I18nConfig>;
+    readI18nFileAsync(locale: string): Promise<{ [id: string]: any }>;
+    writeI18nFileAsync(locale: string, i18n: any): Promise<void>;
+    buildFunction(name: string, value: string): I18nFunction;
+    generateUpdateAsync(): Promise<void>;
+}
+
+interface CommandInput {
+    name: string;
+    range: Range;
+}
+
+export class InsertActionProvider implements CodeActionProvider {
+    readonly actionName = "flutterI18nInsert";
+    readonly delegate: InsertActionProviderDelegate;
+    readonly filter: DocumentFilter = { language: "dart", scheme: "file" };
+    readonly regex = RegExp('^The getter \'(.*)\' isn\'t defined for the class \'I18n\'.');
+
+    constructor(delegate: InsertActionProviderDelegate) {
+        this.delegate = delegate;
+    }
+
+    extractName(context: CodeActionContext): [string, Diagnostic] | null {
+        for (let obj of context.diagnostics) {
+            if (obj.code === "undefined_getter") {
+                let result = this.regex.exec(obj.message);
+                if (result && result.length === 2) {
+                    return [result[1], obj];
+                }
+            }
+        }
+        return null;
+    }
+    provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext): CodeAction[] {
+        let result = this.extractName(context);
+        if (result) {
+            let action = new CodeAction("I18n: add localization string", CodeActionKind.QuickFix);
+            let input: CommandInput = {
+                name: result[0],
+                range: range
+            };
+
+            action.command = {
+                title: action.title,
+                command: this.actionName,
+                arguments: [
+                    input
+                ]
+            };
+            action.diagnostics = [result[1]];
+            action.isPreferred = true;
+            return [action];
+        }
+        return [];
+    }
+
+    async insertAsync(input: CommandInput): Promise<void> {
+        try {
+            await this.insertAsyncThrowing(input);
+        } catch (error) {
+            console.log(error);
+            window.showErrorMessage(error.message);
+        }
+    }
+
+    async addEntryToDefaultLocale(key: string, value: string): Promise<void> {
+        const config = await this.delegate.readConfigFileAsync();
+        const locale = config.defaultLocale || "";
+
+        const defaultI18n = await this.delegate.readI18nFileAsync(locale);
+
+        if (defaultI18n.hasOwnProperty(key)) {
+            window.showInformationMessage(`Key ${key} already exists.`);
+            return;
+        }
+
+        defaultI18n[key] = value;
+        await this.delegate.writeI18nFileAsync(locale, defaultI18n);
+    }
+
+    async insertAsyncThrowing(input: CommandInput): Promise<void> {
+        let key = input.name;
+
+        let value = await window.showInputBox({
+            prompt: "Please enter key for the new localization value",
+            placeHolder: "Value"
+        });
+
+        if (!key || !value) {
+            window.showInformationMessage(`Adding key was cancelled.`);
+            return;
+        }
+
+        await this.addEntryToDefaultLocale(key, value);
+
+        let generated = this.delegate.buildFunction(key, value);
+        if (generated.variables) {
+            let joined = generated.variables.join(', ');
+            let methodCall = "(" + joined + ")";
+
+            window.activeTextEditor!.edit((x) => {
+                x.insert(input.range.end, methodCall);
+            });
+        }
+
+        await this.delegate.generateUpdateAsync();
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,18 @@
 import {
     commands,
     window,
-    ExtensionContext
+    ExtensionContext,
+    languages,
 } from "vscode";
 
 import { I18nGenerator } from "./i18n-generator";
 import { FileSystem } from "./file-system";
 import { UserActions } from "./user-actions";
 import { WorkspaceExtensions } from "./workspace-extensions";
+import { InsertActionProvider } from "./InsertActionProvider";
 
 export function activate(context: ExtensionContext) {
     const subscriptions = context.subscriptions;
-
     const workspaceExtensions = new WorkspaceExtensions();
     const workspaceFolder = workspaceExtensions.getWorkspaceFolder();
 
@@ -35,6 +36,13 @@ export function activate(context: ExtensionContext) {
     }));
 
     subscriptions.push(i18nGenerator);
+
+    let provider = new InsertActionProvider(i18nGenerator);
+    subscriptions.push(languages.registerCodeActionsProvider(provider.filter, provider));
+
+    subscriptions.push(commands.registerCommand(provider.actionName, (input) => {
+        provider.insertAsync(input);
+    }));
 }
 
 export function deactivate() { }

--- a/src/i18n-generator.ts
+++ b/src/i18n-generator.ts
@@ -6,8 +6,9 @@ import { I18nConfig, I18nFunction } from "./i18n.interfaces";
 import { FileSystem } from "./file-system";
 import { Hello } from "./hello";
 import { UserActions } from "./user-actions";
+import { InsertActionProviderDelegate } from "./InsertActionProvider";
 
-export class I18nGenerator implements IDisposable {
+export class I18nGenerator implements IDisposable, InsertActionProviderDelegate {
     private static readonly defaultGeneratedPath = "lib/generated";
     private static readonly defaultI18nPath = "i18n";
     private static readonly defaultLocale = "en-US";
@@ -111,7 +112,6 @@ export class I18nGenerator implements IDisposable {
         await this.generateDartFileAsync(config);
 
         await this.ua.showInfo(`Successfully updated localization.`);
-
     }
 
     dispose(): void { }
@@ -270,29 +270,32 @@ export class I18nGenerator implements IDisposable {
         return diffFunctions;
     }
 
+    buildFunction(name: string, value: string): I18nFunction {
+        const variables = this.parseVariables(value);
+        if (variables && variables.length > 0) {
+            const body = this.replaceVariables(value, variables);
+            const parameters = this.getParameters(variables);
+            return {
+                name: name,
+                signature: `String ${name}(${parameters})`,
+                body: `"${this.escapeString(body)}"`,
+                variables: variables
+            };
+        } else {
+            return {
+                name: name,
+                signature: `String get ${name}`,
+                body: `"${this.escapeString(value)}"`,
+                variables: null
+            };
+        }
+    }
+
     private buildFunctionTable(i18n: any): I18nFunction[] {
         const functions: I18nFunction[] = [];
         for (const name in i18n) {
             if (i18n.hasOwnProperty(name)) {
-                const value = i18n[name];
-                const variables = this.parseVariables(value);
-                if (variables && variables.length > 0) {
-                    const body = this.replaceVariables(value, variables);
-                    const parameters = this.getParameters(variables);
-                    functions.push({
-                        name: name,
-                        signature: `String ${name}(${parameters})`,
-                        body: `"${this.escapeString(body)}"`,
-                        variables: variables
-                    });
-                } else {
-                    functions.push({
-                        name: name,
-                        signature: `String get ${name}`,
-                        body: `"${this.escapeString(value)}"`,
-                        variables: null
-                    });
-                }
+                functions.push(this.buildFunction(name, i18n[name]));
             }
         }
         return functions;
@@ -310,12 +313,13 @@ export class I18nGenerator implements IDisposable {
         return s;
     }
 
-    private readI18nFileAsync(locale: string): Promise<{}> {
+
+    readI18nFileAsync(locale: string): Promise<{ [id: string]: any }> {
         const filename = this.fs.combinePath(this.i18nWorkspace, `${locale}.json`);
-        return this.fs.readJsonFileAsync<{}>(filename);
+        return this.fs.readJsonFileAsync(filename);
     }
 
-    private readConfigFileAsync(): Promise<I18nConfig> {
+    readConfigFileAsync(): Promise<I18nConfig> {
         const filename = this.fs.combinePath(this.workspaceFolder, I18nGenerator.i18nConfigFile);
         return this.fs.readJsonFileAsync<I18nConfig>(filename);
     }
@@ -325,7 +329,7 @@ export class I18nGenerator implements IDisposable {
         await this.fs.writeJsonFileAsync(filename, config);
     }
 
-    private async writeI18nFileAsync(locale: string, i18n: any): Promise<void> {
+    async writeI18nFileAsync(locale: string, i18n: any): Promise<void> {
         const filename = this.fs.combinePath(this.i18nWorkspace, `${locale}.json`);
         await this.fs.writeJsonFileAsync(filename, i18n);
     }


### PR DESCRIPTION
This adds a feature where user can start writing `I18n.of(context).foo`, and he will get a code fix that will insert the new key into the default json file and then regenerate the dart files. 

Placeholder values are also supported - they will be automatically added if entered value contains them.

![ext](https://user-images.githubusercontent.com/19707261/59551838-c0379f00-8f7f-11e9-983e-a8238f8a43f9.png)
