### PR TITLE
add documentation for entries

### DIFF
--- a/src/i18n-generator.ts
+++ b/src/i18n-generator.ts
@@ -180,6 +180,9 @@ export class I18nGenerator implements IDisposable {
                 if (functionsContent.length > 0) {
                     functionsContent += "\n  ";
                 }
+
+                functionsContent += `/// ${func.body}\n  `;
+
                 if (overwrite) {
                     functionsContent += "@override\n";
                     functionsContent += "  ";


### PR DESCRIPTION
Adds documentation to each entry so that you can see the value when autocompleting.

![doc](https://user-images.githubusercontent.com/19707261/59559541-10a70f00-9009-11e9-946b-bd8d23b96570.png)
