### PR TITLE
Flatten i18n json to allow nesting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,3 +54,7 @@ export function activate(context: ExtensionContext) {
 }
 
 export function deactivate() { }
+
+String.prototype.upperCaseFirstLetter = function(): String {
+    return this.charAt(0).toUpperCase() + this.slice(1);
+};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+declare interface String {
+    upperCaseFirstLetter(): String;
+}

--- a/src/i18n-generator.ts
+++ b/src/i18n-generator.ts
@@ -126,7 +126,7 @@ export class I18nGenerator implements IDisposable, InsertActionProviderDelegate 
         if (!apiKey) {
             return;
         }
-        
+
         config.googleTranslateApiKey = apiKey;
 
         await this.writeConfigFileAsync(config);
@@ -139,7 +139,7 @@ export class I18nGenerator implements IDisposable, InsertActionProviderDelegate 
             this.ua.showInfo(`Translations created.`);
             await this.generateUpdateAsync();
         }
-    }  
+    }
 
     dispose(): void { }
 
@@ -343,10 +343,10 @@ export class I18nGenerator implements IDisposable, InsertActionProviderDelegate 
         return s;
     }
 
-
-    readI18nFileAsync(locale: string): Promise<{ [id: string]: any }> {
+    async readI18nFileAsync(locale: string): Promise<{ [id: string]: any }> {
         const filename = this.fs.combinePath(this.i18nWorkspace, `${locale}.json`);
-        return this.fs.readJsonFileAsync(filename);
+        var jsonFileContent = await this.fs.readJsonFileAsync(filename);
+        return this.flattenObject(jsonFileContent);
     }
 
     readConfigFileAsync(): Promise<I18nConfig> {
@@ -485,7 +485,7 @@ export class I18nGenerator implements IDisposable, InsertActionProviderDelegate 
         }
         return this.validateLocale(locale);
     }
-    
+
     private validateAPIKeyNotEmpty = (locale: string): string | null => {
         if (!locale) {
             return "API Key cannot be empty";
@@ -585,5 +585,32 @@ class GeneratedLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocali
   @override
   bool shouldReload(GeneratedLocalizationsDelegate old) => I18n._shouldReload;
 }`;
-}
 
+    private flattenObject(obj: any) {
+        var result: any = {};
+        var index = 0;
+        for (var property in obj) {
+            // Consider no inherited properties
+            if (!obj.hasOwnProperty(property)) { continue; }
+            // Check if type 'object', if so flatten incl. children
+            var value = Object.values(obj)[index];
+            if (value instanceof Object) {
+                var flattenedSubObject = this.flattenObject(value);
+                var subIndex = 0;
+                for (var subProperty in flattenedSubObject) {
+                    // Consider no inherited properties
+                    if (!flattenedSubObject.hasOwnProperty(subProperty)) { continue; }
+                    // Populate with concatenated keys and value
+                    result[property + '_' + subProperty] = Object.values(flattenedSubObject)[subIndex];
+                    subIndex++;
+                }
+            } else {
+                // Populate with key-value pair
+                result[property] = Object.values(obj)[index];
+            }
+            index++;
+        }
+        return result;
+    }
+
+}

--- a/src/i18n-generator.ts
+++ b/src/i18n-generator.ts
@@ -601,7 +601,7 @@ class GeneratedLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocali
                     // Consider no inherited properties
                     if (!flattenedSubObject.hasOwnProperty(subProperty)) { continue; }
                     // Populate with concatenated keys and value
-                    result[property + '_' + subProperty] = Object.values(flattenedSubObject)[subIndex];
+                    result[property + subProperty.upperCaseFirstLetter()] = Object.values(flattenedSubObject)[subIndex];
                     subIndex++;
                 }
             } else {


### PR DESCRIPTION
Added a function to the generator flattening the json read from i18n files in order to address #17.
Function also ensures only own properties are considered to make it general purpose. Approach based on https://gist.github.com/penguinboy/762197.

I am not happy with the resulting i18n function signature (underscore). However, the signature is valid and a more elaborate solution (camel case) would mean more effort.

Tested with this JSON:

```json
{
    "greetTo": "Hello {name}",
    "nestedKeys": {
        "textOne" : "Text One!",
        "textTwo" : "Text Two!",
        "subNested": {
            "textThree": "Text Three"
        }
    },
    "testAtTheEnd": "Yup"
}
```

The generator result looks like this:

```ts
  /// "Hello ${name}"
  String greetTo(String name) => "Hello ${name}";
  /// "Text One!"
  String get nestedKeys_textOne => "Text One!";
  /// "Text Two!"
  String get nestedKeys_textTwo => "Text Two!";
  /// "Text Three"
  String get nestedKeys_subNested_textThree => "Text Three";
  /// "Yup"
  String get testAtTheEnd => "Yup";
```

Cheers 🤘🏼