### PR TITLE
Fix linting warning "omit_local_variable_types"

### DIFF
--- a/src/i18n-generator.ts
+++ b/src/i18n-generator.ts
@@ -634,7 +634,7 @@ class GeneratedLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocali
       if (isSupported(locale)) {
         return locale;
       }
-      final Locale fallbackLocale = fallback ?? supported.first;
+      final fallbackLocale = fallback ?? supported.first;
       return fallbackLocale;
     };
   }
@@ -643,8 +643,8 @@ class GeneratedLocalizationsDelegate extends LocalizationsDelegate<WidgetsLocali
   Future<WidgetsLocalizations> load(Locale locale) {
     I18n._locale ??= locale;
     I18n._shouldReload = false;
-    final String lang = I18n._locale != null ? I18n._locale.toString() : "";
-    final String languageCode = I18n._locale != null ? I18n._locale.languageCode : "";
+    final lang = I18n._locale != null ? I18n._locale.toString() : '';
+    final languageCode = I18n._locale != null ? I18n._locale.languageCode : '';
     {cases}
     return SynchronousFuture<WidgetsLocalizations>(const I18n());
   }


### PR DESCRIPTION
Removed types in order to use Dart's type inference (as per Dart style guidelines).

Source: https://dart.dev/guides/language/effective-dart/design#avoid-type-annotating-initialized-local-variables

Plus: I've changed "" to '' in order to satisfy pedantic's linting rule `prefer_single_quotes`. Harmless for non pedantic projects, useful otherwise.

This allows to get rid of the linting warning in vs code caused by the auto generated code.